### PR TITLE
[AIRFLOW-926] Fix JDBC Hook

### DIFF
--- a/airflow/hooks/jdbc_hook.py
+++ b/airflow/hooks/jdbc_hook.py
@@ -52,9 +52,10 @@ class JdbcHook(DbApiHook):
         jdbc_driver_loc = conn.extra_dejson.get('extra__jdbc__drv_path')
         jdbc_driver_name = conn.extra_dejson.get('extra__jdbc__drv_clsname')
 
-        conn = jaydebeapi.connect(jdbc_driver_name,
-                                  [str(host), str(login), str(psw)],
-                                  jdbc_driver_loc,)
+        conn = jaydebeapi.connect(jclassname=jdbc_driver_name,
+                                  url=str(host),
+                                  driver_args=[str(login), str(psw)],
+                                  jars=jdbc_driver_loc.split(sep=","))
         return conn
 
     def set_autocommit(self, conn, autocommit):

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ hive = [
     'impyla>=0.13.3',
     'unicodecsv>=0.14.1'
 ]
-jdbc = ['jaydebeapi>=0.2.0']
+jdbc = ['jaydebeapi>=1.1.1']
 mssql = ['pymssql>=2.1.1', 'unicodecsv>=0.14.1']
 mysql = ['mysqlclient>=1.3.6']
 rabbitmq = ['librabbitmq>=1.6.1']


### PR DESCRIPTION
JayDeBeApi made a backwards incompatible change
This updates the JDBC Hook's implementation
and changes the required JayDeBeApi to >= 1.1.1
